### PR TITLE
Initial spacy matcher utils

### DIFF
--- a/dap_job_quality/utils/TEMP_tester_file.py
+++ b/dap_job_quality/utils/TEMP_tester_file.py
@@ -18,12 +18,9 @@ OUTPUT_PATH = PROJECT_DIR / "outputs/data/keyword_output.csv"
 
 
 if __name__ == "__main__":
-    nlp = spacy.load("en_core_web_sm")
-    matcher = Matcher(nlp.vocab)
-
     raw_df = get_ojo_sample()
     raw_df["clean_description"] = raw_df["description"].apply(clean_text)
     small_df = raw_df.head(1000)
 
-    annotated_df = keyword_search_df(small_df, keywords, matcher, nlp)
+    annotated_df = keyword_search_df(small_df, keywords)
     annotated_df.to_csv(OUTPUT_PATH)

--- a/dap_job_quality/utils/TEMP_tester_file.py
+++ b/dap_job_quality/utils/TEMP_tester_file.py
@@ -1,0 +1,29 @@
+from dap_job_quality import PROJECT_DIR
+from dap_job_quality.getters.ojo_getters import get_ojo_sample
+from dap_job_quality.utils.text_cleaning import clean_text
+
+from dap_job_quality.utils.spacy_keyword_search import keyword_search_df
+from dap_job_quality.utils.keyword_search_patterns import keywords
+
+
+import pandas as pd
+import spacy
+from spacy.matcher import PhraseMatcher, Matcher
+import spacy
+from spacy import displacy
+from spacy.matcher import Matcher
+
+
+OUTPUT_PATH = PROJECT_DIR / "outputs/data/keyword_output.csv"
+
+
+if __name__ == "__main__":
+    nlp = spacy.load("en_core_web_sm")
+    matcher = Matcher(nlp.vocab)
+
+    raw_df = get_ojo_sample()
+    raw_df["clean_description"] = raw_df["description"].apply(clean_text)
+    small_df = raw_df.head(1000)
+
+    annotated_df = keyword_search_df(small_df, keywords, matcher, nlp)
+    annotated_df.to_csv(OUTPUT_PATH)

--- a/dap_job_quality/utils/keyword_search_patterns.py
+++ b/dap_job_quality/utils/keyword_search_patterns.py
@@ -1,0 +1,83 @@
+keywords = [
+    {
+        "dimension": "P&B",
+        "subcategory": "TOTAL_PACKAGE",
+        "patterns": [[{"LOWER": "pension"}], [{"LOWER": "bonus"}]],
+    },
+    {
+        "dimension": "P&B",
+        "subcategory": "LEAVE",
+        "patterns": [
+            [{"LOWER": {"IN": ["leave", "holidays", "vacation"]}}],
+            [{"LOWER": "income"}, {"LOWER": "protection"}],
+        ],
+    },
+    {
+        "dimension": "Work-life balance",
+        "subcategory": "FLEX_HOURS",
+        "patterns": [
+            [
+                {"LOWER": "flexible"},
+                {"LOWER": "working", "OP": "?"},
+                {"LOWER": "hours"},
+            ],
+            [
+                {"LOWER": "flexible"},
+                {"LOWER": "working", "OP": "?"},
+                {"LOWER": "arrangements"},
+            ],
+            [
+                {"LOWER": "compressed"},
+                {"IS_PUNCT": True, "OP": "?"},
+                {"LOWER": "hours"},
+            ],
+            [
+                {"LOWER": "flexible"},
+                {"LOWER": "working", "OP": "?"},
+                {"LOWER": "options"},
+            ],
+        ],
+    },
+    {
+        "dimension": "Work-life balance",
+        "subcategory": "P/T",
+        "patterns": [
+            [{"LOWER": "part"}, {"IS_PUNCT": True, "OP": "?"}, {"LOWER": "time"}],
+            [{"LOWER": "job"}, {"IS_PUNCT": True, "OP": "?"}, {"LOWER": "share"}],
+            [{"LOWER": "jobshare"}],
+        ],
+    },
+    {
+        "dimension": "Work-life balance",
+        "subcategory": "FLEX_LOC",
+        "patterns": [[{"LOWER": {"IN": ["remote", "hybrid"]}}]],
+    },
+    {
+        "dimension": "Job design and nature of work",
+        "subcategory": "L&D",
+        "patterns": [
+            [
+                {
+                    "LOWER": {
+                        "IN": [
+                            "learn",
+                            "develop",
+                            "train",
+                            "learning",
+                            "developing",
+                            "development",
+                            "training",
+                        ]
+                    }
+                }
+            ]
+        ],
+    },
+    {
+        "dimension": "Job design and nature of work",
+        "subcategory": "CAREER",
+        "patterns": [
+            [{"LOWER": {"IN": ["career", "progress", "progression", "advance"]}}]
+        ],
+    },
+]

--- a/dap_job_quality/utils/spacy_keyword_search.py
+++ b/dap_job_quality/utils/spacy_keyword_search.py
@@ -10,7 +10,16 @@ from spacy import displacy
 from spacy.matcher import Matcher
 
 
-def get_matches(text, patterns, matcher, nlp):
+nlp = spacy.load("en_core_web_sm")
+matcher = Matcher(nlp.vocab)
+
+
+def get_matches(
+    text: str,
+    patterns: list,
+    matcher: Matcher = matcher,
+    nlp: spacy.lang.en.English = nlp,
+) -> tuple:
     """Takes text and returns spacy matches, based on the patterns.
 
     Args:
@@ -31,7 +40,7 @@ def get_matches(text, patterns, matcher, nlp):
     return doc, matches
 
 
-def get_spans(doc, matches, nlp):
+def get_spans(doc: spacy.tokens.doc.Doc, matches: list, nlp=nlp) -> list:
     """Takes matches and converts them into the format required for the displacy visualiser.
     This also collapses the matches - if two keywords are found for the same label in the same sentence, the
     label will go from the first letter of the first keyword, to the last letter of the last keyword (including all words in between).
@@ -40,7 +49,11 @@ def get_spans(doc, matches, nlp):
         matches (list): matches (tuples of the match id, start span, end span)
 
     Returns:
-        list: spans in correct format
+        list: list of dictionaries, each containing the start and end token, the label, and the sentence. The format for each dictonary is:
+        {'start_token': [int: the start token of the match],
+        'end_token': [int: the end token of the match],
+        'label': [str: a label from the 'subcategory' in the keyword list],
+        'sent': [str: the sentence containing the match]}
     """
     # Get a list of individual matches
     spans_list = []
@@ -72,7 +85,7 @@ def get_spans(doc, matches, nlp):
     return collapsed_list
 
 
-def render_spans(doc, matches):
+def render_spans(doc: spacy.tokens.doc.Doc, matches: list):
     """Renders the full text with labels shown in a jupyter notebook
 
     Args:
@@ -86,7 +99,12 @@ def render_spans(doc, matches):
     displacy.render(test_input, style="span", manual=True)
 
 
-def keyword_search_df(df, patterns, matcher, nlp):
+def keyword_search_df(
+    df: pd.DataFrame,
+    patterns: list,
+    matcher: Matcher = matcher,
+    nlp: spacy.lang.en.English = nlp,
+) -> pd.DataFrame:
     """Run the keyword search on a dataframe, and add the spans to the dataframe
 
     Args:

--- a/dap_job_quality/utils/spacy_keyword_search.py
+++ b/dap_job_quality/utils/spacy_keyword_search.py
@@ -1,0 +1,105 @@
+from dap_job_quality.getters.ojo_getters import get_ojo_sample
+from dap_job_quality.utils.text_cleaning import clean_text
+
+
+import pandas as pd
+import spacy
+from spacy.matcher import PhraseMatcher, Matcher
+import spacy
+from spacy import displacy
+from spacy.matcher import Matcher
+
+
+def get_matches(text, patterns, matcher, nlp):
+    """Takes text and returns spacy matches, based on the patterns.
+
+    Args:
+        text (str): A string of text
+        patterns (list): a list of spacy matcher patterns, following rule-based patterns: https://spacy.io/usage/rule-based-matching
+        matcher (matcher): a spacy matcher object
+
+    Returns:
+        _type_: spacy doc and list of matches (tuples of the match id, start span, end span)
+    """
+
+    for i in range(0, len(patterns)):
+        matcher.add(patterns[i]["subcategory"], patterns[i]["patterns"])
+
+    doc = nlp(text)
+    matches = matcher(doc)
+
+    return doc, matches
+
+
+def get_spans(doc, matches, nlp):
+    """Takes matches and converts them into the format required for the displacy visualiser.
+    This also collapses the matches - if two keywords are found for the same label in the same sentence, the
+    label will go from the first letter of the first keyword, to the last letter of the last keyword (including all words in between).
+
+    Args:
+        matches (list): matches (tuples of the match id, start span, end span)
+
+    Returns:
+        list: spans in correct format
+    """
+    # Get a list of individual matches
+    spans_list = []
+    for i in matches:
+        entry = {
+            "start_token": i[1],
+            "end_token": i[2],
+            "label": nlp.vocab.strings[i[0]],
+        }
+        spans_list.append(entry)
+
+    # Add the respective sentence for each match
+    for i in spans_list:
+        i["sent"] = doc[i["start_token"]].sent
+
+    # Make a single span per sentence per label
+    collapsed_list = []
+    for span in spans_list:
+        found = False
+        for entry in collapsed_list:
+            if entry["label"] == span["label"] and entry["sent"] == span["sent"]:
+                entry["start_token"] = min(entry["start_token"], span["start_token"])
+                entry["end_token"] = max(entry["end_token"], span["end_token"])
+                found = True
+                break
+        if not found:
+            collapsed_list.append(span)
+
+    return collapsed_list
+
+
+def render_spans(doc, matches):
+    """Renders the full text with labels shown in a jupyter notebook
+
+    Args:
+        matches (list): output of the spacy matcher
+        doc (spacy Doc): spacy doc object
+    """
+    spans_list = get_spans(doc, matches)
+    test_input = displacy.parse_spans(doc)
+    test_input["spans"] = spans_list
+
+    displacy.render(test_input, style="span", manual=True)
+
+
+def keyword_search_df(df, patterns, matcher, nlp):
+    """Run the keyword search on a dataframe, and add the spans to the dataframe
+
+    Args:
+        df (pd.DataFrame): Dataframe containing ojo job ads (with clean data called 'clean_description')
+        patterns (list): the spacy kwyword patterns to search for
+
+    Returns:
+        pd.DataFrame: Dataframe with spans added as a column called 'spans'
+    """
+    df["spans"] = pd.Series()
+
+    for index, row in df.iterrows():
+        doc, matches = get_matches(row["clean_description"], patterns, matcher, nlp)
+        slist = get_spans(doc, matches, nlp)
+        df.at[index, "spans"] = slist
+    return df


### PR DESCRIPTION
---

# Description

This adds an initial dictionary and utils to perform a keyword search in the spacy pipeline - either to help pre-annotate labelling data, or to categorise once benefits are identified (TBD)

Fixes # 29

# Instructions for Reviewer

Because these are utils, I've created temp file to test them - you can test using 

python dap_job_quality/utils/TEMP_tester_file.py

This will run the code, and dump a 1000 row csv into your local directory to check. 

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
