### PR TITLE
Train model on sentences; add random state to PCA

### DIFF
--- a/dap_job_quality/pipeline/sentence_classifier/log_reg.py
+++ b/dap_job_quality/pipeline/sentence_classifier/log_reg.py
@@ -150,8 +150,8 @@ if __name__ == "__main__":
 
     X_val_df = X_val.copy()
 
-    X_train = X_train["span"].tolist()
-    X_val = X_val["span"].tolist()
+    X_train = X_train["sentence"].tolist()
+    X_val = X_val["sentence"].tolist()
 
     scaler = StandardScaler()
 
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     )
 
     # Dimensionality Reduction with PCA
-    pca = PCA(n_components=PCA_VAR)
+    pca = PCA(n_components=PCA_VAR, random_state=LOG_REG_PARAMS["random_state"])
     X_train_pca = pca.fit_transform(X_train)
     X_val_pca = pca.transform(X_val)
     logging.info(X_train_pca.shape)

--- a/dap_job_quality/pipeline/sentence_classifier/prep_training_data.py
+++ b/dap_job_quality/pipeline/sentence_classifier/prep_training_data.py
@@ -3,7 +3,7 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 import spacy
 
-from dap_job_quality import PROJECT_DIR, config, BUCKET_NAME
+from dap_job_quality import PROJECT_DIR, config, BUCKET_NAME, logging
 from dap_job_quality.getters.labelled_data import get_labelled_job_sentences
 from dap_job_quality.getters.data_getters import save_to_s3
 from dap_job_quality.utils import prodigy_data_utils as pdu
@@ -67,10 +67,12 @@ if __name__ == "__main__":
 
     negative_df = pd.DataFrame(list(negative_sentences))
     negative_df["label"] = 0
-    negative_df.columns = ["span", "label"]
+    negative_df.columns = ["sentence", "label"]
+    logging.info(negative_df.head())
 
-    positive_df = labelled_df_clean[["span"]]
+    positive_df = labelled_df_clean[["sentence"]]
     positive_df["label"] = 1
+    logging.info(positive_df.head())
 
     training_ml_df = pd.concat([positive_df, negative_df])
 


### PR DESCRIPTION
---

# Description

- Train the model on sentences. Previously, positive examples (=1) were spans whereas negative examples (=0) were sentences. In this version, the positive examples are the sentences in which the labelled spans are found.
- Add a random state to the PCA dimensionality reduction

Fixes # (issue)

# Instructions for Reviewer

In order to test the code in this PR you need to ...

Please pay special attention to ...

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
