### PR TITLE
Refactor find job quality

### DIFF
--- a/dap_job_quality/config/distilbert_config.yaml
+++ b/dap_job_quality/config/distilbert_config.yaml
@@ -1,5 +1,5 @@
-model: jjzha/jobbert-base-cased
-max_length: 81
+model: distilbert-base-uncased
+max_length: 128
 
 sweep_config:
   method: random
@@ -15,17 +15,3 @@ sweep_config:
       values: [8, 16, 32, 64]
     weight_decay:
       values: [0.1, 0.01, 0.001]
-
-train_config:
-  learning_rate: 0.000002
-  per_device_train_batch_size: 32
-  per_device_eval_batch_size: 32
-  gradient_accumulation_steps: 2
-  weight_decay: 0.1
-  num_train_epochs: 10
-  evaluation_strategy: "epoch"
-  save_strategy: "epoch"
-  metric_for_best_model: "f1"
-  load_best_model_at_end: True
-  early_stopping_patience: 2
-  seed: 1

--- a/dap_job_quality/config/jobbert_config.yaml
+++ b/dap_job_quality/config/jobbert_config.yaml
@@ -1,5 +1,8 @@
-model: distilbert-base-uncased
-max_length: 81
+model: jjzha/jobbert-base-cased
+max_length: 128
+seed: 42
+jq_threshold: 0.3
+cs_threshold: 0.55
 
 sweep_config:
   method: random
@@ -15,3 +18,15 @@ sweep_config:
       values: [8, 16, 32, 64]
     weight_decay:
       values: [0.1, 0.01, 0.001]
+
+train_config:
+  learning_rate: 0.000002
+  per_device_train_batch_size: 32
+  per_device_eval_batch_size: 32
+  weight_decay: 0.1
+  num_train_epochs: 10
+  evaluation_strategy: "epoch"
+  save_strategy: "epoch"
+  metric_for_best_model: "f1"
+  load_best_model_at_end: True
+  early_stopping_patience: 2

--- a/dap_job_quality/getters/jobbert_jq.py
+++ b/dap_job_quality/getters/jobbert_jq.py
@@ -5,7 +5,7 @@ from dap_job_quality import BUCKET_NAME, PROJECT_DIR
 from dap_job_quality.getters.data_getters import download_and_extract_from_s3
 
 MODEL_DIR_LOCAL = PROJECT_DIR / "outputs/models/"
-MODEL_NAME = "jobbert-base-cased-jq-2024-08-05"
+MODEL_NAME = "jobbert-base-cased-jq-2024-08-06"
 
 
 def get_jobbert_jq(model_dir=MODEL_DIR_LOCAL, bucket_name=BUCKET_NAME):

--- a/dap_job_quality/getters/jobbert_jq.py
+++ b/dap_job_quality/getters/jobbert_jq.py
@@ -8,7 +8,7 @@ MODEL_DIR_LOCAL = PROJECT_DIR / "outputs/models/"
 MODEL_NAME = "jobbert-base-cased-jq-2024-08-06"
 
 
-def get_jobbert_jq(model_dir=MODEL_DIR_LOCAL, bucket_name=BUCKET_NAME):
+def get_jobbert_jq(model_dir=MODEL_DIR_LOCAL, bucket_name=BUCKET_NAME, max_length=128):
     logging.info("Downloading the model...")
     download_and_extract_from_s3(
         f"job_quality/sentence_classifier/outputs/{MODEL_NAME}.tar.gz",
@@ -20,6 +20,11 @@ def get_jobbert_jq(model_dir=MODEL_DIR_LOCAL, bucket_name=BUCKET_NAME):
     model = AutoModelForSequenceClassification.from_pretrained(
         model_dir / MODEL_NAME, num_labels=2
     )
-    tokenizer = AutoTokenizer.from_pretrained(model_dir / MODEL_NAME)
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_dir / MODEL_NAME,
+        padding="max_length",
+        truncation=True,
+        max_length=max_length,
+    )
 
     return model, tokenizer

--- a/dap_job_quality/getters/train_val_test.py
+++ b/dap_job_quality/getters/train_val_test.py
@@ -29,7 +29,8 @@ def get_ids(set: str = "train") -> pd.DataFrame:
 
     Returns:
         pd.DataFrame: Dataframe with the columns 'id' and 'majority_label'.
-        'majority_label' is the label that most sentences in that advert have.
+        'majority_label' is the label that most sentences in that advert have ie 1= the majority
+        of sentences are about job quality; 0 = the majority of sentences are not about job quality.
     """
     ids = load_s3_data(
         BUCKET_NAME,

--- a/dap_job_quality/getters/train_val_test.py
+++ b/dap_job_quality/getters/train_val_test.py
@@ -12,6 +12,7 @@ def get_df(set: str = "train") -> pd.DataFrame:
 
     Returns:
         pd.DataFrame: DataFrame with the columns 'id', 'sentence', 'label'.
+        'label' is binary: 0 if the sentence is not related to job quality, 1 if it is.
     """
     df = load_s3_data(
         BUCKET_NAME,

--- a/dap_job_quality/getters/train_val_test.py
+++ b/dap_job_quality/getters/train_val_test.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from dap_job_quality import BUCKET_NAME
+from dap_job_quality.getters.data_getters import load_s3_data
+
+
+def get_df(set: str = "train") -> pd.DataFrame:
+    """Load the training/val/test data.
+
+    Args:
+        set (str, optional): Must be "train", "val" or "test". Defaults to "train".
+
+    Returns:
+        pd.DataFrame: DataFrame with the columns 'id', 'sentence', 'label'.
+    """
+    df = load_s3_data(
+        BUCKET_NAME,
+        f"job_quality/sentence_classifier/inputs/labelled/{set}_df_20240725.parquet",
+    )
+    return df
+
+
+def get_ids(set: str = "train") -> pd.DataFrame:
+    """Get the unique IDs of job adverts in the train/val/test set.
+
+    Args:
+        set (str, optional): Must be "train", "val" or "test". Defaults to "train".
+
+    Returns:
+        pd.DataFrame: Dataframe with the columns 'id' and 'majority_label'.
+        'majority_label' is the label that most sentences in that advert have.
+    """
+    ids = load_s3_data(
+        BUCKET_NAME,
+        f"job_quality/sentence_classifier/inputs/labelled/{set}_ids_20240725.parquet",
+    )
+    return ids

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -38,19 +38,23 @@ import re
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
 import torch
+from transformers import AutoTokenizer, AutoModelForSequenceClassification, pipeline
 
 from typing import List, Union, Tuple
 import time
 
-from dap_job_quality import logging, BUCKET_NAME
+from dap_job_quality import logging, BUCKET_NAME, PROJECT_DIR
 from dap_job_quality.getters.afs_data import get_stratified_sample
 from dap_job_quality.getters.data_getters import save_to_s3
+from dap_job_quality.getters.ojo_getters import get_ojo_sample
+from dap_job_quality.getters.jobbert_jq import get_jobbert_jq
 from dap_job_quality.getters.models import (
     sentence_classifier_pca,
     sentence_classifier_lr,
 )
 from dap_job_quality.getters.keywords import get_keywords
 from dap_job_quality.utils.text_cleaning import clean_text
+from dap_job_quality.getters.data_getters import download_and_extract_from_s3
 
 
 def split_ngrams(
@@ -181,10 +185,15 @@ class JobQuality(object):
         )
         self.ngram_match_bert_transformer.max_seq_length = self.MAX_LENGTH
 
-        # Logistic regression model to predict whether the sentence is about job quality.
-        self.sentence_classifier_model = sentence_classifier_lr()
-        # pca for dimensionality reduction.
-        self.sentence_classifier_pca = sentence_classifier_pca()
+        sentence_classifier_model, sentence_classifier_tokenizer = get_jobbert_jq()
+
+        self.job_quality_classifier = pipeline(
+            "text-classification",
+            model=sentence_classifier_model,
+            tokenizer=sentence_classifier_tokenizer,
+            return_all_scores=False,
+            device=0 if torch.cuda.is_available() else -1,  # Use GPU if available
+        )
 
         # DataFrame containing the target phrases to match against.
         self.LOOKUP = get_keywords()
@@ -243,25 +252,30 @@ class JobQuality(object):
         jobs_df["sentences"] = jobs_df[text_col].apply(lambda x: sent_tokenize(x))
         jobs_df = jobs_df.explode("sentences")
 
-        logging.info(f"Calculating embeddings for {len(jobs_df)} sentences ...")
-        start_time = time.time()
-        ad_embeddings = self.sentence_classifier_bert_transformer.encode(
-            jobs_df["sentences"].tolist(), batch_size=self.batch_size
+        logging.info(
+            f"Predicting job quality sentences for {len(jobs_df)} sentences ..."
         )
-        elapsed_time = time.time() - start_time
-        print(f"Time taken: {elapsed_time:.2f} seconds")
-
-        X_new_pca = self.sentence_classifier_pca.transform(ad_embeddings)
-
-        logging.info(f"Predicting job quality sentences ...")
         start_time = time.time()
-        predictions = self.sentence_classifier_model.predict_proba(X_new_pca)[:, 1]
+        predictions = self.job_quality_classifier(jobs_df["sentences"].tolist())
+
         elapsed_time = time.time() - start_time
         print(f"Time taken: {elapsed_time:.2f} seconds")
 
-        jobs_df["job_quality_prob"] = predictions
+        labels = []
+        pred_scores = []
+        for pred in predictions:
+            labels.append(pred["label"])
+            pred_scores.append(pred["score"])
 
-        job_quality_df = jobs_df[jobs_df["job_quality_prob"] >= self.JQ_THRESHOLD]
+        jobs_df["job_quality_label"] = labels
+        jobs_df["job_quality_prob"] = pred_scores
+
+        job_quality_df = jobs_df[
+            (
+                (jobs_df["job_quality_label"] == "LABEL_1")
+                & (jobs_df["job_quality_prob"] >= self.JQ_THRESHOLD)
+            )
+        ]
 
         return job_quality_df.reset_index(drop=True)
 
@@ -389,6 +403,8 @@ class JobQuality(object):
 
         """
 
+        # TO DO. If len(job_adverts)>1000 do this in a loop? (may be too much to process 100k at a time)
+
         self.job_quality_df = self.extract_job_quality_sentences(
             job_adverts,
             id_col=id_col,
@@ -429,6 +445,13 @@ if __name__ == "__main__":
         help="Run the script in production mode or test",
     )
 
+    parser.add_argument(
+        "--job_ads_type",
+        default="afs",
+        type=str,
+        help="Which dataset to predict job quality measures from, can be 'afs', 'random', or 'evaluation'",
+    )
+
     args = parser.parse_args()
     logging.info(args)
 
@@ -436,10 +459,21 @@ if __name__ == "__main__":
 
     # Import the job adverts
 
-    if args.production:
+    if args.job_ads_type == "afs":
         job_adverts = get_stratified_sample()
-    else:
-        job_adverts = get_stratified_sample().sample(10, random_state=42)
+        id_col = "id"
+        text_col = "clean_description"
+    elif args.job_ads_type == "random":
+        job_adverts = get_ojo_sample()
+        id_col = "id"
+        text_col = "description"
+    # elif args.job_ads_type == 'evaluation':
+    #     job_adverts = # FILL IN
+    # else:
+    #     # LOG warning message
+
+    if not args.production:
+        job_adverts = job_adverts.sample(10, random_state=42)
 
     logging.info(f"Sample size: {len(job_adverts)}")
 
@@ -448,9 +482,15 @@ if __name__ == "__main__":
 
     jq_df_filtered, job_id_to_target_phrase = job_quality.extract_job_quality(
         job_adverts,
-        "id",
-        "clean_description",
+        id_col,
+        text_col,
     )
 
-    filename = f"job_quality/early_years/evaluation_sample/job_ads_prod_{args.production}_sample_{len(job_adverts)}_{today}.parquet"
-    save_to_s3(BUCKET_NAME, jq_df_filtered, filename)
+    filename = f"job_quality/outputs/{args.job_ads_type}/job_ads_prod_{args.production}_n_{len(job_adverts)}_{today}.parquet"
+    save_to_s3(
+        BUCKET_NAME,
+        jq_df_filtered[
+            ["id", "sentences_split", "ngrams", "target_phrase", "cosine_similarity"]
+        ],
+        filename,
+    )

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -37,24 +37,32 @@ import pandas as pd
 import re
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
+import time
 import torch
+from tqdm import tqdm
 from transformers import AutoTokenizer, AutoModelForSequenceClassification, pipeline
-
 from typing import List, Union, Tuple
 import time
 
-from dap_job_quality import logging, BUCKET_NAME, PROJECT_DIR
+from dap_job_quality import logging, BUCKET_NAME, PROJECT_DIR, get_yaml_config
 from dap_job_quality.getters.afs_data import get_stratified_sample
-from dap_job_quality.getters.data_getters import save_to_s3
+from dap_job_quality.getters.data_getters import (
+    save_to_s3,
+    get_s3_data_paths,
+    load_s3_data,
+)
 from dap_job_quality.getters.ojo_getters import get_ojo_sample
 from dap_job_quality.getters.jobbert_jq import get_jobbert_jq
-from dap_job_quality.getters.models import (
-    sentence_classifier_pca,
-    sentence_classifier_lr,
-)
 from dap_job_quality.getters.keywords import get_keywords
 from dap_job_quality.utils.text_cleaning import clean_text
-from dap_job_quality.getters.data_getters import download_and_extract_from_s3
+
+# from dap_job_quality.getters.data_getters import download_and_extract_from_s3
+
+jobbert_config = get_yaml_config(
+    PROJECT_DIR / "dap_job_quality/config/jobbert_config.yaml"
+)
+
+TODAY = datetime.today().strftime("%Y-%m-%d")
 
 
 def split_ngrams(
@@ -141,21 +149,53 @@ def split_text(text: str) -> List[str]:
     return final_splits
 
 
+def split_into_chunks(
+    sentence: str, chunk_size: int = 25, overlap: int = 5
+) -> List[str]:
+    """
+    Splits a sentence into overlapping chunks of a specified size.
+
+    This is useful because although we've tried to split up job adverts into reasonable sentences by various means
+    eg converting bullet points to full stops, splitting on certain delimiters, etc, there are still some very long sentences.
+    Having an overlap of 5 words means that if there is a phrase that you'd want to capture whole eg "learning and development",
+    we should still get that.
+
+    A chunk size of 25 is recommended because EDA of a random sample of 10,000 job ads showed that the upper quartile for
+    number of words in a sentence was 23 (we round up to 25).
+
+    Args:
+        sentence (str): The sentence to be split into chunks.
+        chunk_size (int): The size of each chunk. Default is 25.
+        overlap (int): The number of overlapping words between chunks. Default is 5.
+
+    Returns:
+        List[str]: A list of sentence chunks.
+    """
+    words = sentence.split()
+    chunks = []
+    i = 0
+    while i < len(words):
+        chunk = words[i : i + chunk_size]
+        chunks.append(" ".join(chunk))
+        i += chunk_size - overlap
+    return chunks
+
+
 class JobQuality(object):
     """Find aspects of job quality from job adverts
     Args:
         JQ_THRESHOLD (float, optional): Threshold to use for predicting 1 from the logistic regression sentence quality classifier.
         CS_THRESHOLD (float, optional): The cosine similarity threshold for determining a match.
         batch_size (int, optional):
-        MAX_LENGTH (int, optional): This is the 99th percentile of N tokens in job advert sentences :)
+        MAX_LENGTH (int, optional): Maximum token length for fine-tuned jobbert model.
     """
 
     def __init__(
         self,
-        JQ_THRESHOLD: float = 0.3,
-        CS_THRESHOLD: float = 0.55,
-        batch_size: int = 64,
-        MAX_LENGTH: int = 81,
+        JQ_THRESHOLD: float = jobbert_config["jq_threshold"],
+        CS_THRESHOLD: float = jobbert_config["cs_threshold"],
+        batch_size: int = jobbert_config["train_config"]["per_device_train_batch_size"],
+        MAX_LENGTH: int = jobbert_config["max_length"],
     ):
         self.JQ_THRESHOLD = JQ_THRESHOLD
         self.CS_THRESHOLD = CS_THRESHOLD
@@ -175,17 +215,20 @@ class JobQuality(object):
         nltk.download("stopwords")
 
         # The sentence embedding model to use for encoding the sentences for the sentence classifier.
-        self.sentence_classifier_bert_transformer = SentenceTransformer(
-            "jjzha/jobbert-base-cased", device=self.device
-        )
+        #  not used
+        # self.sentence_classifier_bert_transformer = SentenceTransformer(
+        #     "jjzha/jobbert-base-cased", device=self.device
+        # )
 
         # The sentence embedding model to use for encoding the n-grams and target phrases.
         self.ngram_match_bert_transformer = SentenceTransformer(
             "all-MiniLM-L6-v2", device=self.device
         )
-        self.ngram_match_bert_transformer.max_seq_length = self.MAX_LENGTH
+        # self.ngram_match_bert_transformer.max_seq_length = self.MAX_LENGTH #I don't think this part needs truncation
 
-        sentence_classifier_model, sentence_classifier_tokenizer = get_jobbert_jq()
+        sentence_classifier_model, sentence_classifier_tokenizer = get_jobbert_jq(
+            max_length=self.MAX_LENGTH
+        )
 
         self.job_quality_classifier = pipeline(
             "text-classification",
@@ -251,6 +294,14 @@ class JobQuality(object):
 
         jobs_df["sentences"] = jobs_df[text_col].apply(lambda x: sent_tokenize(x))
         jobs_df = jobs_df.explode("sentences")
+
+        # Make sure there are no super super long sentences
+        jobs_df["chunks"] = jobs_df["sentences"].apply(
+            lambda x: split_into_chunks(x) if len(x.split()) >= 25 else [x]
+        )
+        jobs_df = jobs_df.explode("chunks").reset_index(drop=True)
+        jobs_df = jobs_df.drop(columns=["sentences"])
+        jobs_df = jobs_df.rename(columns={"chunks": "sentences"})
 
         logging.info(
             f"Predicting job quality sentences for {len(jobs_df)} sentences ..."
@@ -446,6 +497,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--sample_size",
+        default=10,
+        type=int,
+        help="Number of job adverts to test on (only used if production=False)",
+    )
+
+    parser.add_argument(
         "--job_ads_type",
         default="afs",
         type=str,
@@ -455,7 +513,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logging.info(args)
 
-    today = datetime.today().strftime("%Y-%m-%d")
+    if not args.production:
+        chunk_size = 20
+    else:
+        chunk_size = 10000
 
     # Import the job adverts
 
@@ -472,25 +533,68 @@ if __name__ == "__main__":
     # else:
     #     # LOG warning message
 
-    if not args.production:
-        job_adverts = job_adverts.sample(10, random_state=42)
+    if not args.production & (len(job_adverts) > args.sample_size):
+        job_adverts = job_adverts.sample(args.sample_size, random_state=42)
 
     logging.info(f"Sample size: {len(job_adverts)}")
+
+    start_time = time.time()
+    start_time_formatted = datetime.fromtimestamp(start_time).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    logging.info(f"Processing started at {start_time_formatted}")
 
     job_quality = JobQuality()
     job_quality.load()
 
-    jq_df_filtered, job_id_to_target_phrase = job_quality.extract_job_quality(
-        job_adverts,
-        id_col,
-        text_col,
+    job_ad_chunks = [
+        job_adverts.iloc[i : i + chunk_size]
+        for i in range(0, len(job_adverts), chunk_size)
+    ]
+
+    interim_folder = f"job_quality/outputs/{args.job_ads_type}/interim/production_{args.production}_n_{len(job_adverts)}_{TODAY}"
+
+    for i, job_chunk in tqdm(enumerate(job_ad_chunks)):
+        logging.info(f"Processing chunk {i}...")
+
+        jq_df_filtered, _ = job_quality.extract_job_quality(
+            job_chunk,
+            id_col,
+            text_col,
+        )
+
+        filename = f"{interim_folder}/job_ads_chunk_{i}.parquet"
+        save_to_s3(
+            BUCKET_NAME,
+            jq_df_filtered[
+                [
+                    "id",
+                    "sentences_split",
+                    "ngrams",
+                    "target_phrase",
+                    "cosine_similarity",
+                ]
+            ],
+            filename,
+        )
+
+    end_time = time.time()
+    logging.info(
+        f"Time taken to process {len(job_adverts)} texts: {end_time - start_time} seconds"
     )
 
-    filename = f"job_quality/outputs/{args.job_ads_type}/job_ads_prod_{args.production}_n_{len(job_adverts)}_{today}.parquet"
+    logging.info("Saving data...")
+    files = get_s3_data_paths(BUCKET_NAME, interim_folder, "*.parquet")
+    print(files)
+    data = pd.DataFrame()
+    for file in files:
+        output_data = pd.concat([output_data, load_s3_data(BUCKET_NAME, file)])
+
+    final_filename = f"job_quality/outputs/{args.job_ads_type}/job_ads_prod_{args.production}_n_{len(job_adverts)}_{TODAY}.parquet"
     save_to_s3(
         BUCKET_NAME,
-        jq_df_filtered[
+        output_data[
             ["id", "sentences_split", "ngrams", "target_phrase", "cosine_similarity"]
         ],
-        filename,
+        final_filename,
     )

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -28,6 +28,7 @@ job_id_to_target_phrase = {123: ['Cycle to work', 'benefits', 'pension', 'pensio
 """
 
 import argparse
+from datasets import Dataset
 from datetime import datetime
 import nltk
 from nltk import ngrams
@@ -303,11 +304,15 @@ class JobQuality(object):
         jobs_df = jobs_df.drop(columns=["sentences"])
         jobs_df = jobs_df.rename(columns={"chunks": "sentences"})
 
+        dataset = Dataset.from_pandas(jobs_df)
+
         logging.info(
             f"Predicting job quality sentences for {len(jobs_df)} sentences ..."
         )
         start_time = time.time()
-        predictions = self.job_quality_classifier(jobs_df["sentences"].tolist())
+        predictions = self.job_quality_classifier(
+            dataset["sentences"], batch_size=self.batch_size
+        )
 
         elapsed_time = time.time() - start_time
         print(f"Time taken: {elapsed_time:.2f} seconds")

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -516,7 +516,7 @@ if __name__ == "__main__":
     if not args.production:
         chunk_size = 20
     else:
-        chunk_size = 10000
+        chunk_size = 1000
 
     # Import the job adverts
 

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -452,23 +452,5 @@ if __name__ == "__main__":
         "clean_description",
     )
 
-    # job_quality_df = job_quality.extract_job_quality_sentences(
-    #     job_adverts,
-    #     "id",
-    #     "clean_description",
-    # )
-
-    # job_quality_df_long = job_quality.extract_ngrams(job_quality_df)
-
-    # ngram_counts = pd.DataFrame(
-    #     job_quality_df_long["ngrams"].value_counts()
-    # ).reset_index()
-
-    # unique_ngrams = ngram_counts["ngrams"]
-
-    # matches = job_quality.match_to_lookup(unique_ngrams)
-
-    # jq_df_filtered = job_quality.match_ngrams_to_adverts(matches, job_quality_df_long)
-
-    # filename = f"job_quality/early_years/evaluation_sample/job_ads_prod_{args.production}_sample_{len(job_adverts)}_{today}.parquet"
-    # save_to_s3(BUCKET_NAME, jq_df_filtered, filename)
+    filename = f"job_quality/early_years/evaluation_sample/job_ads_prod_{args.production}_sample_{len(job_adverts)}_{today}.parquet"
+    save_to_s3(BUCKET_NAME, jq_df_filtered, filename)

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -586,7 +586,7 @@ if __name__ == "__main__":
     logging.info("Saving data...")
     files = get_s3_data_paths(BUCKET_NAME, interim_folder, "*.parquet")
     print(files)
-    data = pd.DataFrame()
+    output_data = pd.DataFrame()
     for file in files:
         output_data = pd.concat([output_data, load_s3_data(BUCKET_NAME, file)])
 

--- a/dap_job_quality/pipeline/find_job_quality.py
+++ b/dap_job_quality/pipeline/find_job_quality.py
@@ -1,6 +1,32 @@
 """
 Pipeline to extract job quality measures from job adverts
+
+
+The class in this script can be used by running:
+
+
+from dap_job_quality.pipeline.find_job_quality import JobQuality
+import pandas as pd
+
+job_quality = JobQuality()
+job_quality.load()
+
+job_adverts = pd.DataFrame(
+    [
+        {'id': 123, 'description': '[This is a job adverts. It has many benefits such as a pension scheme and a cycle to work scheme.]'},
+        {'id': 234, 'description': '[This is a job adverts for a job at a bank. There are free childcare vouchers. We also offer a yearly bonus and generous salary.]'}
+        ]
+)
+
+jq_df_filtered, job_id_to_target_phrase = job_quality.extract_job_quality(job_adverts,
+    "id",
+    "description",)
+
+
+This should give:
+job_id_to_target_phrase = {123: ['Cycle to work', 'benefits', 'pension', 'pension scheme'], 234: ['childcare vouchers', 'compensation', 'performance bonus']}
 """
+
 import argparse
 from datetime import datetime
 import nltk
@@ -11,86 +37,20 @@ import pandas as pd
 import re
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
-from sklearn.decomposition import PCA
-from sklearn.base import BaseEstimator
+import torch
+
 from typing import List, Union, Tuple
+import time
 
 from dap_job_quality import logging, BUCKET_NAME
 from dap_job_quality.getters.afs_data import get_stratified_sample
 from dap_job_quality.getters.data_getters import save_to_s3
-from dap_job_quality.utils import jobbert
 from dap_job_quality.getters.models import (
     sentence_classifier_pca,
     sentence_classifier_lr,
 )
 from dap_job_quality.getters.keywords import get_keywords
-
-nltk.download("punkt")
-nltk.download("stopwords")
-
-sent_model = SentenceTransformer("all-MiniLM-L6-v2")
-JOBBERT = "jjzha/jobbert-base-cased"
-
-model = sentence_classifier_lr()
-pca = sentence_classifier_pca()
-
-today = datetime.today().strftime("%Y-%m-%d")
-
-JQ_THRESHOLD = 0.3
-CS_THRESHOLD = 0.55
-
-LOOKUP = get_keywords()
-
-
-def extract_job_quality_sentences(
-    job_adverts: Union[pd.DataFrame, List[str], str],
-    pca: PCA,
-    model: BaseEstimator,
-    id_col: str = "id",
-    text_col: str = "clean_description",
-    threshold: float = JQ_THRESHOLD,
-) -> pd.DataFrame:
-    """Extracts sentences from job advertisements and predicts the job quality for each sentence.
-    The output dataframe contains sentences where the probability of being about job quality is greater than the threshold.
-
-    Args:
-        job_adverts (Union[pd.DataFrame, List[str], str]): Dataframe, list of strings, or string containing job adverts.
-        pca (PCA): pca for dimensionality reduction.
-        model (BaseEstimator): Logistic regression model to predict whether the sentence is about job quality.
-        id_col (str, optional): Unique identifier for job adverts. Defaults to "id".
-        text_col (str, optional): Column containing the advert text. Defaults to "clean_description".
-        threshold (float, optional): Threshold to use for predicting 1 from the logistic regression. Defaults to JQ_THRESHOLD.
-
-    Returns:
-        pd.DataFrame: _description_
-    """
-    if isinstance(job_adverts, str):
-        jobs_df = pd.DataFrame([{id_col: 0, text_col: job_adverts}])
-    elif isinstance(job_adverts, list):
-        jobs_df = (
-            pd.DataFrame(job_adverts, columns=[text_col])
-            .reset_index()
-            .rename(columns={"index": id_col})
-        )
-    elif isinstance(job_adverts, pd.DataFrame):
-        jobs_df = job_adverts[[id_col, text_col]].copy()
-    else:
-        raise ValueError("Input must be a DataFrame, a list of strings, or a string")
-
-    jobs_df["sentences"] = jobs_df[text_col].apply(lambda x: sent_tokenize(x))
-    jobs_df = jobs_df.explode("sentences")
-
-    ad_embeddings = jobbert.embed_sentences(jobs_df["sentences"].tolist(), JOBBERT, 64)
-
-    X_new_pca = pca.transform(ad_embeddings)
-
-    predictions = model.predict_proba(X_new_pca)[:, 1]
-
-    jobs_df["job_quality_prob"] = predictions
-
-    job_quality_df = jobs_df[jobs_df["job_quality_prob"] >= threshold]
-
-    return job_quality_df.reset_index(drop=True)
+from dap_job_quality.utils.text_cleaning import clean_text
 
 
 def split_ngrams(
@@ -177,117 +137,284 @@ def split_text(text: str) -> List[str]:
     return final_splits
 
 
-def extract_ngrams(
-    job_quality_df: pd.DataFrame, col: str = "sentences"
-) -> pd.DataFrame:
-    """
-    Does some extra cleaning on sentences in the job quality DataFrame and extracts ngrams.
-
-    Parameters:
-    job_quality_df (pd.DataFrame): DataFrame containing sentences with job quality information.
-    col (str): The column name containing the sentences. Defaults to "sentences".
-
-    Returns:
-    pd.DataFrame: A DataFrame with additional columns for split sentences, cleaned sentences, and n-grams.
-    """
-    # perform further cleaning on the sentences
-    job_quality_df["sentences_split"] = job_quality_df[col].apply(split_text)
-    job_quality_df_long = job_quality_df.explode("sentences_split")
-
-    # replace digits with 'X'
-    job_quality_df_long["sentence_cleaned"] = job_quality_df_long[
-        "sentences_split"
-    ].str.replace(r"\d", "X", regex=True)
-
-    # get unique ngrams and their counts
-    job_quality_df_long["ngrams"] = job_quality_df_long["sentence_cleaned"].apply(
-        lambda x: split_ngrams(x, 6, 4)
-    )
-    job_quality_df_long = job_quality_df_long.explode("ngrams")
-    job_quality_df_long["ngrams"] = job_quality_df_long["ngrams"].apply(
-        lambda x: " ".join(x) if isinstance(x, tuple) else x
-    )
-
-    return job_quality_df_long
-
-
-def match_to_lookup(
-    ngrams: Union[pd.Series, List[str]],
-    lookup: pd.DataFrame,
-    sent_model,
-    threshold: float,
-) -> pd.DataFrame:
-    """
-    Matches n-grams to a lookup table of target phrases using cosine similarity.
-
-    Parameters:
-    ngrams (Union[pd.Series, List[str]]): The n-grams to be matched.
-    lookup (pd.DataFrame): DataFrame containing the target phrases to match against.
-    sent_model: The sentence embedding model to use for encoding the n-grams and target phrases.
-    threshold (float): The cosine similarity threshold for determining a match.
-
-    Returns:
-    pd.DataFrame: A DataFrame containing n-grams, their most similar target phrases, and cosine similarities.
-    """
-    target_phrases = lookup["target_phrase"].tolist()
-
-    target_embeddings = sent_model.encode(target_phrases)
-
-    ngram_embeddings = sent_model.encode(ngrams)
-
-    similarities = cosine_similarity(ngram_embeddings, target_embeddings)
-
-    # Find the index of the highest cosine similarity for each n-gram/lookup phrase combination
-    max_indices = np.argmax(similarities, axis=1)
-
-    # Retrieve the text of the corresponding target phrases
-    most_similar_phrases = [target_phrases[index] for index in max_indices]
-
-    most_similar_similarities = [
-        similarities[i, index] for i, index in enumerate(max_indices)
-    ]
-
-    most_similar_pairs = list(
-        zip(ngrams, most_similar_phrases, most_similar_similarities)
-    )
-
-    matches = pd.DataFrame(
-        most_similar_pairs, columns=["ngrams", "target_phrase", "cosine_similarity"]
-    )
-
-    return matches[matches["cosine_similarity"] >= threshold]
-
-
-def match_ngrams_to_adverts(
-    matches: pd.DataFrame, job_quality_df_long: pd.DataFrame
-) -> pd.DataFrame:
-    """
-    Merges a dataframe of matched n-grams with a dataframe of job advertisements and filters the results based on cosine similarity.
-
-    Parameters:
-    matches (pd.DataFrame): DataFrame containing n-grams and their matched target phrases with cosine similarities.
-    job_quality_df_long (pd.DataFrame): DataFrame containing job quality information with n-grams.
-
-    Returns:
-    pd.DataFrame: A filtered DataFrame with matched n-grams and their corresponding job advertisements.
+class JobQuality(object):
+    """Find aspects of job quality from job adverts
+    Args:
+        JQ_THRESHOLD (float, optional): Threshold to use for predicting 1 from the logistic regression sentence quality classifier.
+        CS_THRESHOLD (float, optional): The cosine similarity threshold for determining a match.
+        batch_size (int, optional):
+        MAX_LENGTH (int, optional): This is the 99th percentile of N tokens in job advert sentences :)
     """
 
-    job_quality_df_long = pd.merge(
-        job_quality_df_long, matches, how="left", left_on="ngrams", right_on="ngrams"
-    )
+    def __init__(
+        self,
+        JQ_THRESHOLD: float = 0.3,
+        CS_THRESHOLD: float = 0.55,
+        batch_size: int = 64,
+        MAX_LENGTH: int = 81,
+    ):
+        self.JQ_THRESHOLD = JQ_THRESHOLD
+        self.CS_THRESHOLD = CS_THRESHOLD
+        self.batch_size = batch_size
+        self.MAX_LENGTH = MAX_LENGTH
 
-    # Group by 'sentence_cleaned' and 'target_phrase' and find index of max cosine similarity so that you don't get multiple matches
-    # to the same target phrase
-    idx = job_quality_df_long.groupby(["sentence_cleaned", "target_phrase"])[
-        "cosine_similarity"
-    ].idxmax()
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    # Select the rows with these indices
-    jq_df_filtered = job_quality_df_long.loc[idx].reset_index(drop=True)
+    def load(self):
+        """
+        Load the neccessary models and variables
+        """
 
-    return jq_df_filtered.drop(
-        ["sentences", "job_quality_prob", "sentence_cleaned"], axis=1
-    )
+        logging.info(f"Loading models and variables")
+
+        nltk.download("punkt")
+        nltk.download("stopwords")
+
+        # The sentence embedding model to use for encoding the sentences for the sentence classifier.
+        self.sentence_classifier_bert_transformer = SentenceTransformer(
+            "jjzha/jobbert-base-cased", device=self.device
+        )
+
+        # The sentence embedding model to use for encoding the n-grams and target phrases.
+        self.ngram_match_bert_transformer = SentenceTransformer(
+            "all-MiniLM-L6-v2", device=self.device
+        )
+        self.ngram_match_bert_transformer.max_seq_length = self.MAX_LENGTH
+
+        # Logistic regression model to predict whether the sentence is about job quality.
+        self.sentence_classifier_model = sentence_classifier_lr()
+        # pca for dimensionality reduction.
+        self.sentence_classifier_pca = sentence_classifier_pca()
+
+        # DataFrame containing the target phrases to match against.
+        self.LOOKUP = get_keywords()
+        self.target_phrases = self.LOOKUP["target_phrase"].tolist()
+        # Calculate the embeddings for the target phrases since this is only needs to happen once
+        logging.info(
+            f"Calculating embeddings for {len(self.target_phrases)} target phrases ..."
+        )
+        self.target_embeddings = self.ngram_match_bert_transformer.encode(
+            self.target_phrases
+        )
+
+    def extract_job_quality_sentences(
+        self,
+        job_adverts: Union[pd.DataFrame, List[str], str],
+        id_col: str = "id",
+        text_col: str = "clean_description",
+        clean_job_adverts: bool = True,
+    ) -> pd.DataFrame:
+        """Extracts sentences from job advertisements and predicts the job quality for each sentence.
+        The output dataframe contains sentences where the probability of being about job quality is greater than the threshold.
+
+        Args:
+            job_adverts (Union[pd.DataFrame, List[str], str]): Dataframe, list of strings, or string containing job adverts.
+            id_col (str, optional): Unique identifier for job adverts. Defaults to "id".
+            text_col (str, optional): Column containing the advert text. Defaults to "clean_description".
+
+        Returns:
+            pd.DataFrame: _description_
+        """
+        if isinstance(job_adverts, str):
+            jobs_df = pd.DataFrame([{id_col: 0, text_col: job_adverts}])
+        elif isinstance(job_adverts, list):
+            jobs_df = (
+                pd.DataFrame(job_adverts, columns=[text_col])
+                .reset_index()
+                .rename(columns={"index": id_col})
+            )
+        elif isinstance(job_adverts, pd.DataFrame):
+            jobs_df = job_adverts[[id_col, text_col]].copy()
+        else:
+            raise ValueError(
+                "Input must be a DataFrame, a list of strings, or a string"
+            )
+
+        if clean_job_adverts:
+            jobs_df["clean_description"] = (
+                jobs_df[text_col]
+                .apply(clean_text)
+                .str.replace("[", "")
+                .str.replace("]", "")
+                .str.strip()
+            )
+            text_col = "clean_description"
+
+        jobs_df["sentences"] = jobs_df[text_col].apply(lambda x: sent_tokenize(x))
+        jobs_df = jobs_df.explode("sentences")
+
+        logging.info(f"Calculating embeddings for {len(jobs_df)} sentences ...")
+        start_time = time.time()
+        ad_embeddings = self.sentence_classifier_bert_transformer.encode(
+            jobs_df["sentences"].tolist(), batch_size=self.batch_size
+        )
+        elapsed_time = time.time() - start_time
+        print(f"Time taken: {elapsed_time:.2f} seconds")
+
+        X_new_pca = self.sentence_classifier_pca.transform(ad_embeddings)
+
+        logging.info(f"Predicting job quality sentences ...")
+        start_time = time.time()
+        predictions = self.sentence_classifier_model.predict_proba(X_new_pca)[:, 1]
+        elapsed_time = time.time() - start_time
+        print(f"Time taken: {elapsed_time:.2f} seconds")
+
+        jobs_df["job_quality_prob"] = predictions
+
+        job_quality_df = jobs_df[jobs_df["job_quality_prob"] >= self.JQ_THRESHOLD]
+
+        return job_quality_df.reset_index(drop=True)
+
+    def extract_ngrams(
+        self, job_quality_df: pd.DataFrame, col: str = "sentences"
+    ) -> pd.DataFrame:
+        """
+        Does some extra cleaning on sentences in the job quality DataFrame and extracts ngrams.
+
+        Parameters:
+        job_quality_df (pd.DataFrame): DataFrame containing sentences with job quality information.
+        col (str): The column name containing the sentences. Defaults to "sentences".
+
+        Returns:
+        pd.DataFrame: A DataFrame with additional columns for split sentences, cleaned sentences, and n-grams.
+        """
+        # perform further cleaning on the sentences
+        job_quality_df["sentences_split"] = job_quality_df[col].apply(split_text)
+        job_quality_df_long = job_quality_df.explode("sentences_split")
+
+        # replace digits with 'X'
+        job_quality_df_long["sentence_cleaned"] = job_quality_df_long[
+            "sentences_split"
+        ].str.replace(r"\d", "X", regex=True)
+
+        # get unique ngrams and their counts
+        job_quality_df_long["ngrams"] = job_quality_df_long["sentence_cleaned"].apply(
+            lambda x: split_ngrams(x, 6, 4)
+        )
+        job_quality_df_long = job_quality_df_long.explode("ngrams")
+        job_quality_df_long["ngrams"] = job_quality_df_long["ngrams"].apply(
+            lambda x: " ".join(x) if isinstance(x, tuple) else x
+        )
+
+        return job_quality_df_long
+
+    def match_to_lookup(
+        self,
+        ngrams: Union[pd.Series, List[str]],
+    ) -> pd.DataFrame:
+        """
+        Matches n-grams to a lookup table of target phrases using cosine similarity.
+
+        Parameters:
+        ngrams (Union[pd.Series, List[str]]): The n-grams to be matched.
+
+        Returns:
+        pd.DataFrame: A DataFrame containing n-grams, their most similar target phrases, and cosine similarities.
+        """
+
+        logging.info(f"Calculating embeddings for {len(ngrams)} ngrams ...")
+        start_time = time.time()
+        ngram_embeddings = self.ngram_match_bert_transformer.encode(ngrams)
+        elapsed_time = time.time() - start_time
+        print(f"Time taken: {elapsed_time:.2f} seconds")
+
+        similarities = cosine_similarity(ngram_embeddings, self.target_embeddings)
+
+        # Find the index of the highest cosine similarity for each n-gram/lookup phrase combination
+        max_indices = np.argmax(similarities, axis=1)
+
+        # Retrieve the text of the corresponding target phrases
+        most_similar_phrases = [self.target_phrases[index] for index in max_indices]
+
+        most_similar_similarities = [
+            similarities[i, index] for i, index in enumerate(max_indices)
+        ]
+
+        most_similar_pairs = list(
+            zip(ngrams, most_similar_phrases, most_similar_similarities)
+        )
+
+        matches = pd.DataFrame(
+            most_similar_pairs, columns=["ngrams", "target_phrase", "cosine_similarity"]
+        )
+
+        return matches[matches["cosine_similarity"] >= self.CS_THRESHOLD]
+
+    def match_ngrams_to_adverts(
+        self, matches: pd.DataFrame, job_quality_df_long: pd.DataFrame
+    ) -> pd.DataFrame:
+        """
+        Merges a dataframe of matched n-grams with a dataframe of job advertisements and filters the results based on cosine similarity.
+
+        Parameters:
+        matches (pd.DataFrame): DataFrame containing n-grams and their matched target phrases with cosine similarities.
+        job_quality_df_long (pd.DataFrame): DataFrame containing job quality information with n-grams.
+
+        Returns:
+        pd.DataFrame: A filtered DataFrame with matched n-grams and their corresponding job advertisements.
+        """
+
+        job_quality_df_long = pd.merge(
+            job_quality_df_long,
+            matches,
+            how="left",
+            left_on="ngrams",
+            right_on="ngrams",
+        )
+
+        # Group by 'sentence_cleaned' and 'target_phrase' and find index of max cosine similarity so that you don't get multiple matches
+        # to the same target phrase
+        idx = job_quality_df_long.groupby(["sentence_cleaned", "target_phrase"])[
+            "cosine_similarity"
+        ].idxmax()
+
+        # Select the rows with these indices
+        jq_df_filtered = job_quality_df_long.loc[idx].reset_index(drop=True)
+
+        return jq_df_filtered.drop(
+            ["sentences", "job_quality_prob", "sentence_cleaned"], axis=1
+        )
+
+    def extract_job_quality(
+        self,
+        job_adverts: Union[pd.DataFrame, List[str], str],
+        id_col: str = "id",
+        text_col: str = "clean_description",
+    ):
+        """
+        Args:
+            job_adverts (Union[pd.DataFrame, List[str], str]): Dataframe, list of strings, or string containing job adverts.
+            id_col (str, optional): Unique identifier for job adverts. Defaults to "id".
+            text_col (str, optional): Column containing the advert text. Defaults to "clean_description".
+
+        """
+
+        self.job_quality_df = self.extract_job_quality_sentences(
+            job_adverts,
+            id_col=id_col,
+            text_col=text_col,
+        )
+        self.job_quality_df_long = self.extract_ngrams(self.job_quality_df)
+
+        ngram_counts = pd.DataFrame(
+            self.job_quality_df_long["ngrams"].value_counts()
+        ).reset_index()
+
+        unique_ngrams = ngram_counts["ngrams"]
+
+        self.matches = self.match_to_lookup(unique_ngrams)
+
+        jq_df_filtered = self.match_ngrams_to_adverts(
+            self.matches, self.job_quality_df_long
+        )
+
+        job_id_to_target_phrase = (
+            jq_df_filtered.groupby("id")["target_phrase"]
+            .apply(lambda x: x.tolist())
+            .to_dict()
+        )
+
+        return jq_df_filtered, job_id_to_target_phrase
 
 
 if __name__ == "__main__":
@@ -305,35 +432,43 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logging.info(args)
 
+    today = datetime.today().strftime("%Y-%m-%d")
+
     # Import the job adverts
 
     if args.production:
         job_adverts = get_stratified_sample()
     else:
-        job_adverts = get_stratified_sample().sample(10)
+        job_adverts = get_stratified_sample().sample(10, random_state=42)
 
     logging.info(f"Sample size: {len(job_adverts)}")
 
-    job_quality_df = extract_job_quality_sentences(
+    job_quality = JobQuality()
+    job_quality.load()
+
+    jq_df_filtered, job_id_to_target_phrase = job_quality.extract_job_quality(
         job_adverts,
-        pca,
-        model,
         "id",
         "clean_description",
-        JQ_THRESHOLD,
     )
 
-    job_quality_df_long = extract_ngrams(job_quality_df)
+    # job_quality_df = job_quality.extract_job_quality_sentences(
+    #     job_adverts,
+    #     "id",
+    #     "clean_description",
+    # )
 
-    ngram_counts = pd.DataFrame(
-        job_quality_df_long["ngrams"].value_counts()
-    ).reset_index()
+    # job_quality_df_long = job_quality.extract_ngrams(job_quality_df)
 
-    unique_ngrams = ngram_counts["ngrams"]
+    # ngram_counts = pd.DataFrame(
+    #     job_quality_df_long["ngrams"].value_counts()
+    # ).reset_index()
 
-    matches = match_to_lookup(unique_ngrams, LOOKUP, sent_model, CS_THRESHOLD)
+    # unique_ngrams = ngram_counts["ngrams"]
 
-    jq_df_filtered = match_ngrams_to_adverts(matches, job_quality_df_long)
+    # matches = job_quality.match_to_lookup(unique_ngrams)
 
-    filename = f"job_quality/early_years/evaluation_sample/job_ads_prod_{args.production}_sample_{len(job_adverts)}_{today}.parquet"
-    save_to_s3(BUCKET_NAME, jq_df_filtered, filename)
+    # jq_df_filtered = job_quality.match_ngrams_to_adverts(matches, job_quality_df_long)
+
+    # filename = f"job_quality/early_years/evaluation_sample/job_ads_prod_{args.production}_sample_{len(job_adverts)}_{today}.parquet"
+    # save_to_s3(BUCKET_NAME, jq_df_filtered, filename)

--- a/dap_job_quality/pipeline/sentence_classifier/classifier_utils.py
+++ b/dap_job_quality/pipeline/sentence_classifier/classifier_utils.py
@@ -30,6 +30,7 @@ from dap_job_quality.getters.data_getters import (
     upload_file_to_s3,
     save_to_s3,
 )
+from dap_job_quality.getters.train_val_test import get_df
 
 
 def log_confusion_matrix_img(cm, outpath, filename):
@@ -51,14 +52,8 @@ def log_confusion_matrix_table(cm):
 
 
 def load_datasets_for_hf():
-    train_df = load_s3_data(
-        BUCKET_NAME,
-        "job_quality/sentence_classifier/inputs/labelled/train_df_20240725.parquet",
-    )
-    val_df = load_s3_data(
-        BUCKET_NAME,
-        "job_quality/sentence_classifier/inputs/labelled/val_df_20240725.parquet",
-    )
+    train_df = get_df("train")
+    val_df = get_df("val")
 
     train_df.rename(columns={"label": "labels"}, inplace=True)
     val_df.rename(columns={"label": "labels"}, inplace=True)

--- a/dap_job_quality/pipeline/sentence_classifier/jobbert_train.py
+++ b/dap_job_quality/pipeline/sentence_classifier/jobbert_train.py
@@ -1,24 +1,12 @@
 import argparse
 from datetime import datetime
-import matplotlib
 
-matplotlib.use(
-    "Agg"
-)  # Use a non-interactive backend for matplotlib so that it (hopefully) works on EC2
-import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
+import os
 import random
 from scipy.special import softmax
-from sklearn.metrics import (
-    classification_report,
-    confusion_matrix,
-    ConfusionMatrixDisplay,
-    accuracy_score,
-    f1_score,
-    recall_score,
-    precision_recall_fscore_support,
-)
+import shutil
+from sklearn.metrics import confusion_matrix
 import wandb
 
 
@@ -31,32 +19,27 @@ from transformers import (
     Trainer,
     EarlyStoppingCallback,
 )
-from datasets import load_dataset, load_metric, Dataset
+from datasets import Dataset
 
-from dap_job_quality import BUCKET_NAME, logging, PROJECT_DIR, get_yaml_config
-from dap_job_quality.getters.data_getters import load_s3_data
-from dap_job_quality.utils import jobbert
+from dap_job_quality import logging, PROJECT_DIR, get_yaml_config
 from dap_job_quality.pipeline.sentence_classifier.classifier_utils import (
     load_datasets_for_hf,
     log_confusion_matrix_img,
     tokenize_function,
     log_confusion_matrix_table,
     log_summary_metrics,
-    get_best_hyperparams,
-    load_training_args,
     saving_huggingface_model,
     compute_metrics,
-    # saving_huggingface_tokenizer,
+)
+
+jobbert_config = get_yaml_config(
+    PROJECT_DIR / "dap_job_quality/config/jobbert_config.yaml"
 )
 
 TODAY = datetime.today().strftime("%Y-%m-%d")
-SEED = 42
+SEED = jobbert_config["seed"]
 random.seed(SEED)
 np.random.seed(SEED)
-
-jobbert_config = get_yaml_config(
-    PROJECT_DIR / "dap_job_quality/pipeline/sentence_classifier/jobbert_config.yaml"
-)
 
 CONF_MAT_OUTPATH = PROJECT_DIR / "outputs/figures/"
 INPUT_MODEL_NAME = "jjzha/jobbert-base-cased"
@@ -66,6 +49,13 @@ LOCAL_SAVE_PATH = (
     PROJECT_DIR / f"outputs/models/sentence_classifier/{OUTPUT_MODEL_NAME}"
 )
 S3_SAVE_PATH = "job_quality/sentence_classifier/outputs/"
+CHECKPOINT_DIR = PROJECT_DIR / "outputs/models/sentence_classifier/checkpoints/"
+
+MAX_LENGTH = jobbert_config["max_length"]
+
+if os.path.exists(CHECKPOINT_DIR):
+    shutil.rmtree(CHECKPOINT_DIR)
+os.makedirs(CHECKPOINT_DIR)
 
 model = AutoModelForSequenceClassification.from_pretrained(
     INPUT_MODEL_NAME, num_labels=2
@@ -108,19 +98,19 @@ if __name__ == "__main__":
     tokenized_train_dataset = train_dataset.map(
         tokenize_function,
         batched=True,
-        fn_kwargs={"tokenizer": tokenizer, "max_length": 128},
+        fn_kwargs={"tokenizer": tokenizer, "max_length": MAX_LENGTH},
     )
     tokenized_val_dataset = val_dataset.map(
         tokenize_function,
         batched=True,
-        fn_kwargs={"tokenizer": tokenizer, "max_length": 128},
+        fn_kwargs={"tokenizer": tokenizer, "max_length": MAX_LENGTH},
     )
 
     # data collator
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
     training_args = TrainingArguments(
-        output_dir=PROJECT_DIR / "outputs/models/",
+        output_dir=CHECKPOINT_DIR,
         learning_rate=jobbert_config["train_config"]["learning_rate"],
         per_device_train_batch_size=jobbert_config["train_config"][
             "per_device_train_batch_size"
@@ -128,16 +118,13 @@ if __name__ == "__main__":
         per_device_eval_batch_size=jobbert_config["train_config"][
             "per_device_eval_batch_size"
         ],
-        gradient_accumulation_steps=jobbert_config["train_config"][
-            "gradient_accumulation_steps"
-        ],
         weight_decay=jobbert_config["train_config"]["weight_decay"],
         num_train_epochs=jobbert_config["train_config"]["num_train_epochs"],
         evaluation_strategy=jobbert_config["train_config"]["evaluation_strategy"],
         save_strategy=jobbert_config["train_config"]["save_strategy"],
         metric_for_best_model=jobbert_config["train_config"]["metric_for_best_model"],
         load_best_model_at_end=jobbert_config["train_config"]["load_best_model_at_end"],
-        seed=jobbert_config["train_config"]["seed"],
+        seed=jobbert_config["seed"],
         report_to="wandb",
     )
 


### PR DESCRIPTION
---

# Description

Hope this is an ok refactor, I think it means `jobbert_inference.py` may be redundant.

I took out `from dap_job_quality.utils import jobbert` since it felt nicer to load the model in the `load` function and then use it for embeddings later.

# To do

- [x] I expect that the code may be really slow if the user calls `job_quality.extract_job_quality(job_adverts)` with loads of job adverts. I suggest editing the `extract_job_quality` function so that job quality measures are calculated for batches of job adverts and a tqdm progress bar is displayed. I suspect this might be more optimal.
- [ ] Allow an option for running this as a script wth the evaluation dataset

# Instructions for Reviewer

- [x] Run the script on a sample of 10 ASF job adverts:

```
python dap_job_quality/pipeline/find_job_quality.py --job_ads_type "asf"
```
- [x] Run the script on a sample of 10 random job adverts:

```
python dap_job_quality/pipeline/find_job_quality.py --job_ads_type "random"
```
- [x] Check the outputs make sense (in s3://open-jobs-lake/job_quality/outputs/)


- [x] In python/ a notebook run the class like a user would on their own job adverts:

```
from dap_job_quality.pipeline.find_job_quality import JobQuality
import pandas as pd

job_quality = JobQuality()
job_quality.load()

job_adverts = pd.DataFrame(
    [
        {'id': 123, 'description': '[This is a job adverts. It has many benefits such as a pension scheme and a cycle to work scheme.]'},
        {'id': 234, 'description': '[This is a job adverts for a job at a bank. There are free childcare vouchers. We also offer a yearly bonus and generous salary.]'}
        ]
)

jq_df_filtered, job_id_to_target_phrase = job_quality.extract_job_quality(job_adverts,
    "id",
    "description",)

```

This should give:
job_id_to_target_phrase = {123: ['Cycle to work', 'benefits', 'pension', 'pension scheme'], 234: ['childcare vouchers', 'compensation', 'performance bonus']}


# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
