### PR TITLE
Remove chunking from evaluation of sentence classifier

### DIFF
--- a/dap_job_quality/analysis/full_pipeline_evaluation/sentence_evaluation.ipynb
+++ b/dap_job_quality/analysis/full_pipeline_evaluation/sentence_evaluation.ipynb
@@ -16,7 +16,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-09-03 16:42:01,158 - datasets - INFO - PyTorch version 2.1.2 available.\n"
+      "2024-09-25 11:38:03,828 - datasets - INFO - PyTorch version 2.1.2 available.\n"
      ]
     },
     {
@@ -31,9 +31,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-09-03 16:42:05,628 - botocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials\n",
-      "2024-09-03 16:42:05,799 - root - INFO - Loading models and variables\n",
-      "2024-09-03 16:42:05,949 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n"
+      "2024-09-25 11:38:06,164 - botocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials\n",
+      "2024-09-25 11:38:06,323 - root - INFO - Loading models and variables\n",
+      "2024-09-25 11:38:06,464 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n"
      ]
     },
     {
@@ -52,9 +52,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-09-03 16:42:06,202 - root - INFO - Downloading the model...\n",
-      "2024-09-03 16:42:54,471 - root - INFO - Loading the model and tokenizer...\n",
-      "2024-09-03 16:42:54,820 - aiobotocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials\n"
+      "2024-09-25 11:38:06,633 - root - INFO - Downloading the model...\n",
+      "2024-09-25 11:38:54,348 - root - INFO - Loading the model and tokenizer...\n",
+      "2024-09-25 11:38:54,663 - aiobotocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials\n"
      ]
     },
     {
@@ -69,14 +69,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-09-03 16:42:55,181 - root - INFO - Calculating embeddings for 131 target phrases ...\n"
+      "2024-09-25 11:38:55,011 - root - INFO - Calculating embeddings for 131 target phrases ...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Batches: 100%|██████████| 5/5 [00:00<00:00,  7.33it/s]\n"
+      "Batches: 100%|██████████| 5/5 [00:00<00:00,  9.04it/s]\n"
      ]
     }
    ],
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -122,33 +122,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time taken: 94.54 seconds\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_54502/163966962.py:10: SettingWithCopyWarning: \n",
+      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_59457/3769224282.py:23: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  df[\"chunks\"] = df[\"sentence\"].apply(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Time taken: 66.36 seconds\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_54502/163966962.py:37: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  df[\"job_quality_label\"] = labels\n",
+      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_59457/3769224282.py:24: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df[\"job_quality_prob\"] = pred_scores\n",
+      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_59457/3769224282.py:27: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  df['job_quality_label'] = df['job_quality_label'].replace({'LABEL_0': 0, 'LABEL_1': 1})\n",
+      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_59457/3769224282.py:27: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  df['job_quality_label'] = df['job_quality_label'].replace({'LABEL_0': 0, 'LABEL_1': 1})\n"
      ]
     },
@@ -156,14 +162,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 12.93 seconds\n"
+      "Time taken: 15.95 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_54502/163966962.py:37: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_59457/3769224282.py:27: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
       "  df['job_quality_label'] = df['job_quality_label'].replace({'LABEL_0': 0, 'LABEL_1': 1})\n"
      ]
     },
@@ -171,14 +177,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 14.47 seconds\n"
+      "Time taken: 24.32 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_54502/163966962.py:37: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "/var/folders/x3/w5p1j0m5745bvc10jk_w36900000gn/T/ipykernel_59457/3769224282.py:27: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
       "  df['job_quality_label'] = df['job_quality_label'].replace({'LABEL_0': 0, 'LABEL_1': 1})\n"
      ]
     }
@@ -190,16 +196,6 @@
     "    \n",
     "    df = df[df['sentence'].notna()] # there were 3 NAs in the training set! Not sure how this happened\n",
     "    \n",
-    "    dataset = Dataset.from_pandas(df)\n",
-    "\n",
-    "    # Make sure there are no super super long sentences\n",
-    "    df[\"chunks\"] = df[\"sentence\"].apply(\n",
-    "                lambda x: split_into_chunks(x) if len(x.split()) >= 25 else [x]\n",
-    "            )\n",
-    "    df = df.explode(\"chunks\").reset_index(drop=True)\n",
-    "    df = df.drop(columns=[\"sentence\"])\n",
-    "    df = df.rename(columns={\"chunks\": \"sentence\"})\n",
-    "\n",
     "    dataset = Dataset.from_pandas(df)\n",
     "\n",
     "    start_time = time.time()\n",
@@ -227,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -235,14 +231,14 @@
      "output_type": "stream",
      "text": [
       "train set confusion matrix:\n",
-      "[[748  85]\n",
-      " [285 828]]\n",
+      "[[514  56]\n",
+      " [ 64 548]]\n",
       "val set confusion matrix:\n",
-      "[[155  12]\n",
-      " [ 42 149]]\n",
+      "[[ 95   5]\n",
+      " [ 15 100]]\n",
       "test set confusion matrix:\n",
-      "[[150  20]\n",
-      " [ 55 219]]\n"
+      "[[106  17]\n",
+      " [ 12 115]]\n"
      ]
     }
    ],
@@ -258,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -292,49 +288,49 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>precision</th>\n",
-       "      <td>0.724105</td>\n",
-       "      <td>0.906900</td>\n",
-       "      <td>0.809866</td>\n",
-       "      <td>0.815502</td>\n",
-       "      <td>0.828653</td>\n",
+       "      <td>0.889273</td>\n",
+       "      <td>0.907285</td>\n",
+       "      <td>0.898477</td>\n",
+       "      <td>0.898279</td>\n",
+       "      <td>0.898599</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>recall</th>\n",
-       "      <td>0.897959</td>\n",
-       "      <td>0.743935</td>\n",
-       "      <td>0.809866</td>\n",
-       "      <td>0.820947</td>\n",
-       "      <td>0.809866</td>\n",
+       "      <td>0.901754</td>\n",
+       "      <td>0.895425</td>\n",
+       "      <td>0.898477</td>\n",
+       "      <td>0.898590</td>\n",
+       "      <td>0.898477</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>f1-score</th>\n",
-       "      <td>0.801715</td>\n",
-       "      <td>0.817374</td>\n",
-       "      <td>0.809866</td>\n",
-       "      <td>0.809545</td>\n",
-       "      <td>0.810671</td>\n",
+       "      <td>0.895470</td>\n",
+       "      <td>0.901316</td>\n",
+       "      <td>0.898477</td>\n",
+       "      <td>0.898393</td>\n",
+       "      <td>0.898497</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>support</th>\n",
-       "      <td>833.000000</td>\n",
-       "      <td>1113.000000</td>\n",
-       "      <td>0.809866</td>\n",
-       "      <td>1946.000000</td>\n",
-       "      <td>1946.000000</td>\n",
+       "      <td>570.000000</td>\n",
+       "      <td>612.000000</td>\n",
+       "      <td>0.898477</td>\n",
+       "      <td>1182.000000</td>\n",
+       "      <td>1182.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                    0            1  accuracy    macro avg  weighted avg\n",
-       "precision    0.724105     0.906900  0.809866     0.815502      0.828653\n",
-       "recall       0.897959     0.743935  0.809866     0.820947      0.809866\n",
-       "f1-score     0.801715     0.817374  0.809866     0.809545      0.810671\n",
-       "support    833.000000  1113.000000  0.809866  1946.000000   1946.000000"
+       "                    0           1  accuracy    macro avg  weighted avg\n",
+       "precision    0.889273    0.907285  0.898477     0.898279      0.898599\n",
+       "recall       0.901754    0.895425  0.898477     0.898590      0.898477\n",
+       "f1-score     0.895470    0.901316  0.898477     0.898393      0.898497\n",
+       "support    570.000000  612.000000  0.898477  1182.000000   1182.000000"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -379,35 +375,35 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>precision</th>\n",
-       "      <td>0.786802</td>\n",
-       "      <td>0.925466</td>\n",
-       "      <td>0.849162</td>\n",
-       "      <td>0.856134</td>\n",
-       "      <td>0.860782</td>\n",
+       "      <td>0.863636</td>\n",
+       "      <td>0.952381</td>\n",
+       "      <td>0.906977</td>\n",
+       "      <td>0.908009</td>\n",
+       "      <td>0.911104</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>recall</th>\n",
-       "      <td>0.928144</td>\n",
-       "      <td>0.780105</td>\n",
-       "      <td>0.849162</td>\n",
-       "      <td>0.854124</td>\n",
-       "      <td>0.849162</td>\n",
+       "      <td>0.950000</td>\n",
+       "      <td>0.869565</td>\n",
+       "      <td>0.906977</td>\n",
+       "      <td>0.909783</td>\n",
+       "      <td>0.906977</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>f1-score</th>\n",
-       "      <td>0.851648</td>\n",
-       "      <td>0.846591</td>\n",
-       "      <td>0.849162</td>\n",
-       "      <td>0.849120</td>\n",
-       "      <td>0.848950</td>\n",
+       "      <td>0.904762</td>\n",
+       "      <td>0.909091</td>\n",
+       "      <td>0.906977</td>\n",
+       "      <td>0.906926</td>\n",
+       "      <td>0.907077</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>support</th>\n",
-       "      <td>167.000000</td>\n",
-       "      <td>191.000000</td>\n",
-       "      <td>0.849162</td>\n",
-       "      <td>358.000000</td>\n",
-       "      <td>358.000000</td>\n",
+       "      <td>100.000000</td>\n",
+       "      <td>115.000000</td>\n",
+       "      <td>0.906977</td>\n",
+       "      <td>215.000000</td>\n",
+       "      <td>215.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -415,13 +411,13 @@
       ],
       "text/plain": [
        "                    0           1  accuracy   macro avg  weighted avg\n",
-       "precision    0.786802    0.925466  0.849162    0.856134      0.860782\n",
-       "recall       0.928144    0.780105  0.849162    0.854124      0.849162\n",
-       "f1-score     0.851648    0.846591  0.849162    0.849120      0.848950\n",
-       "support    167.000000  191.000000  0.849162  358.000000    358.000000"
+       "precision    0.863636    0.952381  0.906977    0.908009      0.911104\n",
+       "recall       0.950000    0.869565  0.906977    0.909783      0.906977\n",
+       "f1-score     0.904762    0.909091  0.906977    0.906926      0.907077\n",
+       "support    100.000000  115.000000  0.906977  215.000000    215.000000"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -432,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -466,35 +462,35 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>precision</th>\n",
-       "      <td>0.731707</td>\n",
-       "      <td>0.916318</td>\n",
-       "      <td>0.831081</td>\n",
-       "      <td>0.824013</td>\n",
-       "      <td>0.845634</td>\n",
+       "      <td>0.898305</td>\n",
+       "      <td>0.871212</td>\n",
+       "      <td>0.884</td>\n",
+       "      <td>0.884759</td>\n",
+       "      <td>0.884542</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>recall</th>\n",
-       "      <td>0.882353</td>\n",
-       "      <td>0.799270</td>\n",
-       "      <td>0.831081</td>\n",
-       "      <td>0.840812</td>\n",
-       "      <td>0.831081</td>\n",
+       "      <td>0.861789</td>\n",
+       "      <td>0.905512</td>\n",
+       "      <td>0.884</td>\n",
+       "      <td>0.883650</td>\n",
+       "      <td>0.884000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>f1-score</th>\n",
-       "      <td>0.800000</td>\n",
-       "      <td>0.853801</td>\n",
-       "      <td>0.831081</td>\n",
-       "      <td>0.826901</td>\n",
-       "      <td>0.833202</td>\n",
+       "      <td>0.879668</td>\n",
+       "      <td>0.888031</td>\n",
+       "      <td>0.884</td>\n",
+       "      <td>0.883849</td>\n",
+       "      <td>0.883916</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>support</th>\n",
-       "      <td>170.000000</td>\n",
-       "      <td>274.000000</td>\n",
-       "      <td>0.831081</td>\n",
-       "      <td>444.000000</td>\n",
-       "      <td>444.000000</td>\n",
+       "      <td>123.000000</td>\n",
+       "      <td>127.000000</td>\n",
+       "      <td>0.884</td>\n",
+       "      <td>250.000000</td>\n",
+       "      <td>250.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -502,13 +498,13 @@
       ],
       "text/plain": [
        "                    0           1  accuracy   macro avg  weighted avg\n",
-       "precision    0.731707    0.916318  0.831081    0.824013      0.845634\n",
-       "recall       0.882353    0.799270  0.831081    0.840812      0.831081\n",
-       "f1-score     0.800000    0.853801  0.831081    0.826901      0.833202\n",
-       "support    170.000000  274.000000  0.831081  444.000000    444.000000"
+       "precision    0.898305    0.871212     0.884    0.884759      0.884542\n",
+       "recall       0.861789    0.905512     0.884    0.883650      0.884000\n",
+       "f1-score     0.879668    0.888031     0.884    0.883849      0.883916\n",
+       "support    123.000000  127.000000     0.884  250.000000    250.000000"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/dap_job_quality/pipeline/sentence_classifier/README.md
+++ b/dap_job_quality/pipeline/sentence_classifier/README.md
@@ -44,9 +44,9 @@ The final metrics on the training, validation and test datasets were:
 
 |            | Accuracy | F1   | Precision | Recall |
 | ---------- | -------- | ---- | --------- | ------ |
-| Train      | 0.81     | 0.82 | 0.91      | 0.74   |
-| Validation | 0.85     | 0.85 | 0.93      | 0.78   |
-| Test       | 0.83     | 0.85 | 0.92      | 0.80   |
+| Train      | 0.90     | 0.90 | 0.91      | 0.90   |
+| Validation | 0.91     | 0.91 | 0.95      | 0.87   |
+| Test       | 0.88     | 0.89 | 0.87      | 0.91   |
 
 _Note that a weights and biases account is needed to run these scripts._
 


### PR DESCRIPTION
This ensures that the data is preprocessed for evaluation in exactly the same way as how it is preprocessed for model training.

Although we add an extra chunking step in `find_job_quality.py` to remove long sentences (which can cause the model to take longer to run), we choose to train and evaluate on whole sentences.

---

# Description

Removes a chunking step from how the data is preprocessed prior to evaluating the model.

Fixes #75

# Instructions for Reviewer

In order to test the code in this PR you need to ...

Run the notebook `sentence_evaluation.ipynb`

Please pay special attention to ...

Whether the metrics produced in the notebook match up to those that I've added in the README.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
